### PR TITLE
Add explanation to home pages telling users to check their spam folde…

### DIFF
--- a/app/controllers/cfp/people_controller.rb
+++ b/app/controllers/cfp/people_controller.rb
@@ -53,6 +53,16 @@ class Cfp::PeopleController < ApplicationController
 
   def update
     @person = current_user.person
+   # validates that public name hasn't already been taken
+    pub_name = person_params[:public_name]
+    if pub_name == "Enter a public name here"
+      flash[:danger] = "This public name has already been taken!"
+      return redirect_to action: :edit
+    elsif pub_name != @person.public_name && Person.where(public_name: pub_name).count > 0
+      flash[:danger] = "This public name has already been taken!"
+      return redirect_to action: :edit
+    end
+    
     if person_invalid_for_update
       flash[:alert] = "You must fill out all the required fields!"
       return redirect_to action: :edit

--- a/app/views/cfp/sessions/new.html.haml
+++ b/app/views/cfp/sessions/new.html.haml
@@ -32,6 +32,7 @@
             = f.input :email
             = f.input :password
             = f.input :password_confirmation
+            %p{style: "font-size: 15px; font-weight: bold;"} Please contact us if you don’t receive a confirmation email within 10 minutes after signing up! And don’t forget to check your spam folder ;)
           .actions
             = f.button :submit, t("cfp.sign_up"), class: 'primary'
             = link_to t("cfp.back"), new_cfp_session_path, class: "btn"

--- a/app/views/sessions/new.html.haml
+++ b/app/views/sessions/new.html.haml
@@ -32,6 +32,7 @@
             = f.input :email
             = f.input :password
             = f.input :password_confirmation
+            %p{style: "font-size: 15px; font-weight: bold;"} Please contact us if you don’t receive a confirmation email within 10 minutes after signing up! And don’t forget to check your spam folder ;)
           .actions
             = f.button :submit, t("cfp.sign_up"), class: 'primary'
             = link_to t("cfp.back"), new_cfp_session_path, class: "btn"


### PR DESCRIPTION
…r for confirmation email or contact IFF if they haven't received one. Add logic to CFP people controller to flash danger if public name has already been taken.