### PR TITLE
Add update_state to cfp events controller so that users can confirm t…

### DIFF
--- a/app/controllers/cfp/events_controller.rb
+++ b/app/controllers/cfp/events_controller.rb
@@ -102,6 +102,19 @@ class Cfp::EventsController < ApplicationController
     end
   end
 
+  def update_state
+    authorize! :submit, Event
+    @event = current_user.person.events.find(params[:id])
+    respond_to do |format|
+      if @event.update(state: "confirmed")
+        format.html { redirect_to(cfp_person_path, notice: t('cfp.event_updated_notice')) }
+      else
+        flash[:alert] = "An error occured, please contact the IFF staff."
+        format.html { render action: 'show' }
+      end
+    end
+  end
+
   # Delete /cfp/events/1
   def destroy
     authorize! :submit, Event

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -17,4 +17,12 @@ class UserMailer < ActionMailer::Base
   def bulk_mail(user, template)
     mail to: user.email, subject: template.subject, body: template.content_for(user)
   end
+
+  def send_event_accepted_conf(user, event, conference)
+    @user = user
+    @event = event
+    @conference = conference
+    @person = Person.find_by(user_id: user.id)
+    mail to: @user.email, subject: "Your 2018 IFF Event has been accepted!"
+  end
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -157,9 +157,11 @@ class Person < ActiveRecord::Base
     feedback = 0.0
     count = 0
     events.each do |event|
-      if current_feedback = event.average_feedback
-        feedback += current_feedback * event.event_feedbacks_count
-        count += event.event_feedbacks_count
+      if event
+        if current_feedback = event.average_feedback
+          feedback += current_feedback * event.event_feedbacks_count
+          count += event.event_feedbacks_count
+        end
       end
     end
     return nil if count == 0

--- a/app/views/cfp/people/_table.html.haml
+++ b/app/views/cfp/people/_table.html.haml
@@ -28,6 +28,8 @@
         %td
           = link_to t("edit"), edit_cfp_event_path(event), class: "btn small"
           = link_to t("delete"), cfp_event_path(event), class: "btn small", method: :delete, :data => {:confirm => "Are you absolutely sure you want to delete this proposal? This will be final!"}
+          - if event.state == "accepting"
+            = action_button "success", "Confirm", update_state_cfp_event_path(event)
           - if @conference.event_state_visible
             - if event.state == "unconfirmed"
               = link_to t("cfp.confirm"), confirm_cfp_event_path(event), method: :put, class: "btn success small"

--- a/app/views/event_ratings/show.html.haml
+++ b/app/views/event_ratings/show.html.haml
@@ -10,10 +10,7 @@
     %li= link_to "People", people_event_path(@event)
     %li.active= link_to "Ratings", event_event_rating_path(@event)
     %li= link_to "Feedback", event_event_feedbacks_path(@event)
-  .row
-    .span16
-      %small= link_to "Toggle Description >>", "#", data: { function: 'toggle', args: { target: '#full_description' } }
-  #full_description{style: "display:none;"}
+  #full_description
     .row
       .span16
         %p
@@ -26,61 +23,89 @@
             %tbody
               - @event.speakers.each do |person|
                 %tr
-                  %td= image_box person.avatar, :small
                   %td= link_to person.full_name, person
                   %td
-                    %b Average feedback as speaker:
-                    - if average_feedback = person.average_feedback_as_speaker
-                      = sprintf("%.2f / 5.0", average_feedback)
-                    - else
-                      no data
+                    / %b Average feedback as speaker:
+                    / - if average_feedback = person.average_feedback_as_speaker
+                    /   = sprintf("%.2f / 5.0", average_feedback)
+                    / - else
+                    /   no data
     .row
-      .span3
+      .span4
         %p
-          %b Track:
-          = @event.track.try(:name)
-      .span3
+          %b Title:
+          = @event.title        
         %p
-          %b Type:
+          %b Other Presenters:
+          = @event.other_presenters
+        %p
+          %b Theme:
           = @event.event_type
-      .span3
+        %p
+          %b Format:
+          = @event.track.try(:name)
+      .span4
         %p
           %b Language:
           = @event.language
-    .row
-      .span6
         %p
-          %b Abstract:
-          %br/
-          = simple_format @event.abstract
-        - if @event.links
-          %p
-            %b Links:
-            %br/
-            - @event.links.each do |link|
-              = link_to link.title, link.url
-              %br/
-        - unless @event.event_attachments.is_public.empty?
-          %p
-            %b #{t('publich.schedule.files')}:
-            %br/
-            - @event.event_attachments.is_public.each do |attachment|
-              = link_to attachment.link_title, attachment.attachment.url
-              %br/
-      .span10
+          %b Skill Level:
+          = @event.skill_level
         %p
-          %b Description:
-          %br/
-          = simple_format @event.description
+          %b Event Duration in Hours:
+          = @event.time_slots / 4
+      .span8
+        %h3 Description:
+        = simple_format @event.description
+      .span8
+        %p
+          %b Target Audience:
+          = @event.target_audience_experience
+        %p
+          %b Desired Outcome:
+          = @event.desired_outcome 
+        %p
+          %b Presented at IFF Before?:
+          = @event.iff_before      
+    / .row
+    /   .span6
+    /     %p
+    /       %b Abstract:
+    /       %br/
+    /       = simple_format @event.abstract
+    /     - if @event.links
+    /       %p
+    /         %b Links:
+    /         %br/
+    /         - @event.links.each do |link|
+    /           = link_to link.title, link.url
+    /           %br/
+    /     - unless @event.event_attachments.is_public.empty?
+    /       %p
+    /         %b #{t('publich.schedule.files')}:
+    /         %br/
+    /         - @event.event_attachments.is_public.each do |attachment|
+    /           = link_to attachment.link_title, attachment.attachment.url
+    /           %br/
   .row
     .span16
       %h2 My rating
+      %h4 When rating a session, please always consider:
+      %ul
+        %li Does it adhere to the presentation guidelines?
+        %li Does it adequately address the theme it’s submitted under?
+        %li Are the purpose and desired outcome clearly defined?
+        %li Is it inclusive and accessible to many?
+        %li Are the proposed length and format reasonable?
+        %li Does it demonstrate and support collaboration and coordination?
+        %li Is it interesting?
+  
       = simple_form_for @rating, url: event_event_rating_path do |f|
         %fieldset.inputs
           = f.input :rating, as: :rating
           = f.input :comment, input_html: {rows: 3}
         .actions
-          = f.button :submit, class: 'primary'
+          = f.button :submit, class: 'success'
   .row
     .span16
       %h2 All ratings
@@ -107,7 +132,7 @@
                 - if can? :manage, event_rating
                   - event_rating.person = Person.new if event_rating.person.nil?
                   %tr
-                    %td=image_box event_rating.person.avatar, :small
+                    %td
                     %td=event_rating.person.full_name
                     %td
                       = raty_for("event_rating_#{event_rating.id}", event_rating.rating)

--- a/app/views/events/_table.html.haml
+++ b/app/views/events/_table.html.haml
@@ -6,11 +6,12 @@
         %th= sort_link @search, :title, 'Title', term: params[:term]
         - if @conference.ticket_server_enabled?
           %th= sort_link @search, :ticket_id, 'Ticket', term: params[:term]
-        %th= sort_link @search, :track_name, 'Track', term: params[:term]
-        %th= sort_link @search, :event_type, 'Type', term: params[:term]
+        %th= sort_link @search, :other_presenters, 'Other Presenters', term: params[:term]
+        %th= sort_link @search, :track_name, 'Format', term: params[:term]
+        %th= sort_link @search, :event_type, 'Theme', term: params[:term]
         - if can? :crud, Event
           %th= sort_link @search, :state, 'State', term: params[:term]
-        %th= sort_link @search, :created_at, term: params[:term]
+        /%th= sort_link @search, :created_at, term: params[:term]
       - else
         %th Title
         - if @conference.ticket_server_enabled?
@@ -24,7 +25,8 @@
   %tbody
     - collection.each do |event|
       %tr
-        %td= link_to (image_box event.logo, :small), event
+        %td
+          /= link_to (image_box event.logo, :small), event
         %td
           = link_to event.title, event
           %p.small
@@ -38,13 +40,15 @@
                 = event.ticket.remote_ticket_id
               -else
                 = link_to event.ticket.remote_ticket_id, get_ticket_view_url( event.ticket.remote_ticket_id ), target: "_blank"
+        %td= event.other_presenters
         %td= link_to_unless (params[:track_name].present? or event.track.nil?), event.track.try(:name), url_for(params.merge({:track_name => event.track.try(:name)}))
         %td= link_to_unless params[:event_type].present?, event.event_type, url_for(params.merge({:event_type => event.event_type}))
         - if can? :crud, Event
           %td= link_to_unless params[:event_state].present?, event.state, url_for(params.merge({:event_state => event.state}))
-        %td= l(event.created_at.to_date)
+        
+        /%td= l(event.created_at.to_date)
         %td.buttons
           = action_button "small", 'Show', event
           - if can? :crud, event
             = action_button "small", 'Edit', edit_event_path(event)
-            = action_button "small danger", 'Destroy', event, confirm: 'Are you sure?', method: :delete
+            = action_button "small danger", 'Destroy', event, confirm: 'Are you sure?', method: :delete, :data => {:confirm => "Are you absolutely sure you want to delete this event? This will be final!"}

--- a/app/views/events/ratings.html.haml
+++ b/app/views/events/ratings.html.haml
@@ -39,6 +39,8 @@
           = @events_no_review
     .row
       .span16
+        = actions_bar do
+          = will_paginate @events
         %table.zebra-striped
           %thead
             %tr

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -11,6 +11,8 @@
             = action_button "danger", "Reject event", update_state_event_path(@event, transition: :reject, send_mail: true), method: :put, confirm: "Are you sure?", hint: "Reject this event. The speaker(s) will be notified of the rejection via email."
         - if @event.transition_possible? :accept
           = action_button "success", "Accept event (no email)", update_state_event_path(@event, transition: :accept), method: :put, hint: "Accept this event without sending an automated email."
+        - if @event.transition_possible? :accept
+          = action_button "success", "Accept event (Email)", update_state_with_email_event_path(@event, transition: :accept), method: :put, hint: "Accept this event and send an automated email."
         - if @event.transition_possible? :reject
           = action_button "danger", "Reject event (no email)", update_state_event_path(@event, transition: :reject), method: :put, confirm: "Are you sure?", hint: "Reject this event without sending an automated email."
         - if @event.transition_possible? :confirm
@@ -37,14 +39,18 @@
     .span6
       %h2= t(:basic_information)
       %p
-        %b= Event.human_attribute_name(:subtitle) + ':'
-        = @event.subtitle
-      %p
         %b= Event.human_attribute_name(:track) + ':'
         = @event.track_name
       %p
-        %b= Event.human_attribute_name(:event_type) + ':'
-        = @event.event_type
+        %b= "Other Presenters:"
+        = @event.other_presenters
+      %p
+        %b= "Theme:"
+        = @event.event_type       
+      %p
+        %b Format:
+        = @event.track      
+      
       - if can? :crud, Event
         %p
           %b= Event.human_attribute_name(:state) + ':'
@@ -58,16 +64,30 @@
             = link_to @event.ticket.remote_ticket_id, get_ticket_view_url( @event.ticket.remote_ticket_id ), target: "_blank"
       %p
         %b Language:
-        = @event.language
+        = @event.language 
       %p
-        %b Public:
-        = check_box_tag :public, @event.public, @event.public, disabled: true
+        %b Skill Level:
+        = @event.skill_level
+      %p
+        %b Event Duration in Hours:
+        = @event.time_slots / 4
+      %p
+        %b Presented IFF Before?:
+        = @event.iff_before
       %p
         %b Average audience feedback:
         = number_with_precision @event.average_feedback, precision: 1
     .span6
       %h2= EventPerson.model_name.human(count: 2)
       %p= @event.speakers.map{ |p| link_to p.public_name, p}.join(", ").html_safe
+      %h2 Description:
+      = simple_format @event.description
+      %p
+        %b Target Audience:
+        = @event.target_audience_experience
+      %p
+        %b Desired Outcome:
+        = @event.desired_outcome
       %h2 Scheduling
       %p
         %b Time slots:
@@ -85,17 +105,22 @@
     .span4
       = image_box @event.logo, :large
   .row
-    .span16
-      %h2 Content
+    - if @submitter.dif
+      .span6
+        %h2 DIF
+        %b Status: 
+        = @submitter.dif.status
+        %br/
+        %b Type of Travel Support Requested: 
+        = @submitter.dif.travel_support      
+        %br/
+        %b Received travel assistance in the past?: 
+        = @submitter.dif.past_travel_assistance
+        %br/
+        %b Willing to Fascilitate?
+        = @submitter.dif.willing_to_facilitate
   .row
-    .span6
-      %p
-        %b Abstract:
-        = simple_format @event.abstract
     .span10
-      %p
-        %b Description:
-        = simple_format @event.description
       %p
         - if @event.links.any?
           %b Links:
@@ -113,32 +138,21 @@
     .span16
       %h2 Notes
   .row
+    .span8
+      %p
+        %b Submission Notes(user and admin):
+        = @event.submission_note
+      %p
+        %b Public:
+        = check_box_tag :public, @event.public, @event.public, disabled: true
+      %p
+        %b Abstract:
+        = simple_format @event.abstract
+      %p
+        %b= Event.human_attribute_name(:tech_rider) + ':'
+        = @event.tech_rider
     - if can? :crud, @event
       .span8
         %p
           %b Notes(admin):
           = @event.note
-    .span8
-      %p
-        %b Submission Notes(user and admin):
-        = @event.submission_note
-  .row
-    .span8
-      %p
-        %b= Event.human_attribute_name(:tech_rider) + ':'
-        = @event.tech_rider
-  .row
-    - if @submitter.dif
-      .span6
-        %h2 DIF
-        %b Status: 
-        = @submitter.dif.status
-        %br/
-        %b Type of Travel Support Requested: 
-        = @submitter.dif.travel_support      
-        %br/
-        %b Received travel assistance in the past?: 
-        = @submitter.dif.past_travel_assistance
-        %br/
-        %b Willing to Fascilitate?
-        = @submitter.dif.willing_to_facilitate

--- a/app/views/user_mailer/send_event_accepted_conf.en.text.erb
+++ b/app/views/user_mailer/send_event_accepted_conf.en.text.erb
@@ -1,0 +1,17 @@
+Hello <%= @person.public_name %>!
+
+Your event '<%= @event.title %>' was accepted to be presented at the <%= @conference.title %>!
+
+
+We just wanted to make sure you still want to present at this event. Follow the link below to your user page and click the "Confirm Event" button next to your event. 
+
+<%= cfp_user_confirmation_url(locale: I18n.locale, confirmation_token: @user.confirmation_token, conference_acronym: Conference.current.acronym) %>
+
+Testing: Try this one too! (this doesn't have the confirmation token attached)
+<%= cfp_person_url(locale: I18n.locale, confirmation_token: @user.confirmation_token, conference_acronym: Conference.current.acronym) %>
+
+Thanks for choosing to present at the IFF 2018!
+
+
+Lots of love,
+The IFF Team

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,11 +43,12 @@ Frab::Application.routes.draw do
         end
 
         get '/events/:id/confirm/:token' => 'events#confirm', as: 'event_confirm_by_token'
-
+        get '/events/:id/update_state' => 'events#update_state', as: 'update_state_cfp_event_path'
         resources :events do
           member do
             put :withdraw
             put :confirm
+            put :update_state
           end
         end
 
@@ -115,6 +116,7 @@ Frab::Application.routes.draw do
           get :edit_people
           get :ticket
           put :update_state
+          put :update_state_with_email
           post :custom_notification
         end
         resource :event_rating


### PR DESCRIPTION
…hey want to present an event by clicking the button next to their event. In eventsController (not cfp) add update_state_with_email action to send UserMailer email with link to user home page. Remove avatar from admin events and event ratings. Remove off toggle to view event rating descriptions. Add event data to event and rating on admin side. Changed event data presented in table for admin. Admins can now accept an event with email (new button).