### PR TITLE
Configure crew with role of reviewer to allow fellows to read events …

### DIFF
--- a/app/controllers/cfp/people_controller.rb
+++ b/app/controllers/cfp/people_controller.rb
@@ -9,7 +9,8 @@ class Cfp::PeopleController < ApplicationController
     @person.public_name == "Enter a public name here" ? @not_registered = true : @not_registered =false
     @person.events.count > 0 ? @no_events = false : @no_events = true
     @person.dif.nil? ? @no_dif = true : @no_dif = false
-
+    ConferenceUser.exists?(user_id: current_user.id) ? @is_fellow = true : @is_fellow = false
+    
     return redirect_to action: 'new' unless @person
     if @person.public_name == current_user.email
       flash[:alert] = 'Your email address is not a valid public name, please change it.'

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -7,7 +7,7 @@ class EventsController < ApplicationController
   # GET /events.xml
   def index
     authorize! :read, Event
-
+    @person = current_user.person
     @events = search @conference.events.includes(:track), params
     clean_events_attributes
     respond_to do |format|
@@ -64,7 +64,7 @@ class EventsController < ApplicationController
   # show event ratings
   def ratings
     authorize! :create, EventRating
-
+    
     result = search @conference.events, params
     @events = result.paginate page: page_param
     clean_events_attributes

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -6,7 +6,7 @@ class HomeController < ApplicationController
     return redirect_to new_conference_path if Conference.count.zero?
     return redirect_to cannot_read_redirect_path if cannot? :read, Conference
     return redirect_to deleted_conference_redirect_path if @conference.nil?
-
+    @person = Person.find_by(user_id: current_user.id)
     @versions = PaperTrail::Version.where(conference_id: @conference.id).includes(:item).order('created_at DESC').limit(5)
     respond_to do |format|
       format.html

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -89,6 +89,7 @@ class UsersController < ApplicationController
   # DELETE /users/1
   def destroy
   end
+  
 
   private
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -108,12 +108,12 @@ class Ability
       # reviews events prior to conference schedule release
       # everything from submitter
       # edit own event rating
-      can :read, CallForParticipation
+      # can :read, CallForParticipation
       can [:read, :read_nested_conference], Conference
 
       can :read, Event, conference_id: @conference.id
       can :crud, EventRating, person_id: @user.person.id
-      can :read, EventRating
+      can :manage, EventRating
       can :read, Person
 
     end

--- a/app/views/cfp/people/show.html.haml
+++ b/app/views/cfp/people/show.html.haml
@@ -8,6 +8,9 @@
       = action_button "", t("cfp.edit_registration"), edit_cfp_person_path
       = action_button "", t("cfp.edit_account"), edit_cfp_user_path
     %h2 Welcome to the IFF 2018
+    - if @is_fellow
+      .pull-right
+        = link_to "Go to Fellow Admin", conference_home_path, class: "btn primary"
   .row
     - if @not_registered == false
       .span16{style: "background-color: #1ba5ab; width: 871px; height: 31px; margin-bottom: 15px"}

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -1,6 +1,7 @@
 %section
   .page-header
     .pull-right
+      =link_to "Return to your normal user portal", cfp_person_path(@person.id), class: "btn primary"
       - if can? :crud, Event
         = action_button "primary", "Add event", new_event_path, hint: "Add a new event."
         = action_button "", "Print cards", cards_events_path(format: :pdf), hint: "Download a PDF with all events as cards (four cards per page). Print this out to take your planning offline."

--- a/app/views/events/ratings.html.haml
+++ b/app/views/events/ratings.html.haml
@@ -1,7 +1,8 @@
 %section
   .page-header
     .pull-right
-      = action_button "primary", "Start reviewing", start_review_events_path, hint: "Review a batch of events in a row. You will be presented with the event that has the least ratings first and can easily navigate to the next event in the row."
+      =link_to "Return to your normal user portal", cfp_person_path(@current_user.person.id), class: "btn primary"
+      = action_button "success", "Start reviewing", start_review_events_path, hint: "Review a batch of events in a row. You will be presented with the event that has the least ratings first and can easily navigate to the next event in the row."
     %h1 Event Ratings
   %ul.tabs
     %li= link_to "All Events", events_path

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -1,5 +1,7 @@
 %section
   .page-header
+    .pull-right
+      =link_to "Return to your normal user portal", cfp_person_path(@person.id), class: "btn primary"
     %h1 Welcome
   .row
     .span16

--- a/app/views/people/show.html.haml
+++ b/app/views/people/show.html.haml
@@ -1,6 +1,11 @@
 %section
   .page-header
     .pull-right
+      - if can? :manage, @user
+        - if @user.role == "crew" && !@is_fellow.nil?
+          %h3 Already a Fellow
+        - else  
+          = action_button "success", "Make this person a Fellow", make_fellow_people_path(@person), title: "This will make this person a fellow."
       - if can? :crud, @person
         = action_button "primary", "Edit person", edit_person_path(@person), title: "Edit this person's data."
       - if can? :administrate, Person

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,6 +98,7 @@ Frab::Application.routes.draw do
           get :speakers
           get :volunteers
           get :dif
+          get :make_fellow
         end
       end
 


### PR DESCRIPTION
…and people and manage event ratings (abilities.rb). Add button to admin view of people that allows them to change a users role to crew and their conference user role to reviewer. This, in effect, allows admin to change people into fellows. Add buttons to admin and user side to allow navigation for fellows and admin.