### PR TITLE
Add complete_mailing and complete_mattermost to Person model with mig…

### DIFF
--- a/app/controllers/cfp/people_controller.rb
+++ b/app/controllers/cfp/people_controller.rb
@@ -86,7 +86,7 @@ class Cfp::PeopleController < ApplicationController
 
   def person_params
     params.require(:person).permit(
-      :first_name, :last_name, :public_name, :email, :email_public, :gender, :avatar, :abstract, :description, :include_in_mailings, :include_in_mailings, :pgp_key, :country_of_origin, :other_background, :organization, :project, :title, :invitation_to_mattermost, :iff_goals, :challenges, :other_resources, :interested_in_volunteer, :already_mattermost, :already_mailing, :twitter, :personal_website, { iff_before: [] }, { professional_background: [] },
+      :first_name, :last_name, :public_name, :email, :email_public, :gender, :avatar, :abstract, :description, :include_in_mailings, :include_in_mailings, :pgp_key, :country_of_origin, :other_background, :organization, :project, :title, :invitation_to_mattermost, :iff_goals, :challenges, :other_resources, :interested_in_volunteer, :already_mattermost, :already_mailing, :twitter, :personal_website, :complete_mattermost, :complete_mailing, { iff_before: [] }, { professional_background: [] },
       im_accounts_attributes: %i(id im_type im_address _destroy),
       languages_attributes: %i(id code _destroy),
       links_attributes: %i(id title url _destroy),

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,6 +1,7 @@
 class Person < ActiveRecord::Base
   serialize :professional_background, Array
   serialize :iff_before, Array
+
   GENDERS = ["Female", "Male", "Gender Nonconforming", "Other"].freeze
   COUNTRIES = ["Afghanistan", "Åland Islands", "Albania", "Algeria", "American Samoa", "Andorra", "Angola", "Anguilla", "Antarctica", "Antigua and Barbuda", "Argentina", "Armenia", "Aruba", "Australia", "Austria", "Azerbaijan", "Bahamas", "Bahrain", "Bangladesh", "Barbados", "Belarus", "Belgium", "Belize", "Benin", "Bermuda", "Bhutan", "Bolivia", "Bosnia and Herzegovina", "Botswana", "Bouvet Island", "Brazil", "British Antarctic Territory", "British Indian Ocean Territory", "British Virgin Islands", "Brunei", "Bulgaria", "Burkina Faso", "Burundi", "Cambodia", "Cameroon", "Canada", "Canton and Enderbury Islands", "Cape Verde", "Cayman Islands", "Central African Republic", "Chad", "Chile", "China", "Christmas Island", "Cocos [Keeling] Islands", "Colombia", "Comoros", "Congo - Brazzaville", "Congo - Kinshasa", "Cook Islands", "Costa Rica", "Croatia", "Cuba", "Cyprus", "Czech Republic", "Côte d’Ivoire", "Denmark", "Djibouti", "Dominica", "Dominican Republic", "Dronning Maud Land", "East Germany", "Ecuador", "Egypt", "El Salvador", "Equatorial Guinea", "Eritrea", "Estonia", "Ethiopia", "Falkland Islands", "Faroe Islands", "Fiji", "Finland", "France", "French Guiana", "French Polynesia", "French Southern Territories", "French Southern and Antarctic Territories", "Gabon", "Gambia", "Georgia", "Germany", "Ghana", "Gibraltar", "Greece", "Greenland", "Grenada", "Guadeloupe", "Guam", "Guatemala", "Guernsey", "Guinea", "Guinea-Bissau", "Guyana", "Haiti", "Heard Island and McDonald Islands", "Honduras", "Hong Kong SAR China", "Hungary", "Iceland", "India", "Indonesia", "Iran", "Iraq", "Ireland", "Isle of Man", "Israel", "Italy", "Jamaica", "Japan", "Jersey", "Johnston Island", "Jordan", "Kazakhstan", "Kenya", "Kiribati", "Kuwait", "Kyrgyzstan", "Laos", "Latvia", "Lebanon", "Lesotho", "Liberia", "Libya", "Liechtenstein", "Lithuania", "Luxembourg", "Macau SAR China", "Macedonia", "Madagascar", "Malawi", "Malaysia", "Maldives", "Mali", "Malta", "Marshall Islands", "Martinique", "Mauritania", "Mauritius", "Mayotte", "Metropolitan France", "Mexico", "Micronesia", "Midway Islands", "Moldova", "Monaco", "Mongolia", "Montenegro", "Montserrat", "Morocco", "Mozambique", "Myanmar [Burma]", "Namibia", "Nauru", "Nepal", "Netherlands", "Netherlands Antilles", "Neutral Zone", "New Caledonia", "New Zealand", "Nicaragua", "Niger", "Nigeria", "Niue", "Norfolk Island", "North Korea", "North Vietnam", "Northern Mariana Islands", "Norway", "Oman", "Pacific Islands Trust Territory", "Pakistan", "Palau", "Palestine", "Panama", "Panama Canal Zone", "Papua New Guinea", "Paraguay", "People's Democratic Republic of Yemen", "Peru", "Philippines", "Pitcairn Islands", "Poland", "Portugal", "Puerto Rico", "Qatar", "Romania", "Russia", "Rwanda", "Réunion", "Saint Barthélemy", "Saint Helena", "Saint Kitts and Nevis", "Saint Lucia", "Saint Martin", "Saint Pierre and Miquelon", "Saint Vincent and the Grenadines", "Samoa", "San Marino", "Saudi Arabia", "Senegal", "Serbia", "Serbia and Montenegro", "Seychelles", "Sierra Leone", "Singapore", "Slovakia", "Slovenia", "Solomon Islands", "Somalia", "South Africa", "South Georgia and the South Sandwich Islands", "South Korea", "Spain", "Sri Lanka", "Sudan", "Suriname", "Svalbard and Jan Mayen", "Swaziland", "Sweden", "Switzerland", "Syria", "São Tomé and Príncipe", "Taiwan", "Tajikistan", "Tanzania", "Thailand", "Tibet", "Timor-Leste", "Togo", "Tokelau", "Tonga", "Trinidad and Tobago", "Tunisia", "Turkey", "Turkmenistan", "Turks and Caicos Islands", "Tuvalu", "U.S. Minor Outlying Islands", "U.S. Miscellaneous Pacific Islands", "U.S. Virgin Islands", "Uganda", "Ukraine", "Union of Soviet Socialist Republics", "United Arab Emirates", "United Kingdom", "United States", "Unknown or Invalid Region", "Uruguay", "Uzbekistan", "Vanuatu", "Vatican City", "Venezuela", "Vietnam", "Wake Island", "Wallis and Futuna", "Western Sahara", "Yemen", "Zambia", "Zimbabwe"].freeze
   has_many :availabilities, dependent: :destroy
@@ -37,9 +38,10 @@ class Person < ActiveRecord::Base
   validates_attachment_content_type :avatar, content_type: [/jpg/, /jpeg/, /png/, /gif/]
 
   validates_presence_of :public_name, :email
-  validates :public_name, uniqueness: true, on: :update
-  # validates_inclusion_of :gender, in: GENDERS, allow_nil: true
-  validates_presence_of :country_of_origin, :professional_background, :iff_before, :gender, :on => :update
+  # validates :public_name, uniqueness: true, on: :update
+  ### validates_inclusion_of :gender, in: GENDERS, allow_nil: true
+  
+  # validates_presence_of :country_of_origin, :professional_background, :iff_before, :gender, :on => :update
 
   scope :involved_in, ->(conference) {
     joins(events: :conference).where('conferences.id': conference).uniq
@@ -225,7 +227,7 @@ class Person < ActiveRecord::Base
             if person.try(attr).nil?
               person.dif.send(attr)
             else
-               person.send(attr)
+              person.send(attr)
             end
           end
         else

--- a/app/views/cfp/people/_form.html.haml
+++ b/app/views/cfp/people/_form.html.haml
@@ -15,9 +15,9 @@
         = f.input :last_name, label: "Last Name"
         = f.input :pgp_key, label: "PGP Key", as: :string, hint: "Preferable format: 0xf60a89ad6ff97a2f" 
         .span16{style: "background-color: #fbd38a; padding-top: 5px; padding-bottom: 5px; margin-bottom: 10px"}
-          = f.input :gender, collection: translated_options(Person::GENDERS)
+          = f.input :gender, collection: translated_options(Person::GENDERS), label: "* Gender"
         .span16{style: "background-color: #fbd38a; padding-top: 5px; padding-bottom: 5px; margin-bottom: 10px"}  
-          = f.input :country_of_origin, label: "Country of Origin", collection: translated_options(Person::COUNTRIES), error: " "
+          = f.input :country_of_origin, label: "* Country of Origin", collection: translated_options(Person::COUNTRIES), error: " "
           %b Where are you from?
         = f.input :twitter, label: "Twitter Handle"
         = f.input :personal_website, label: "Personal Website"
@@ -52,23 +52,33 @@
             <hr />
             %p What resources or tools do you think that the IFF community should be aware of? 
             = f.input :other_resources, label: false
-          .span16  
+        /   .span16  
+        /     <hr />
+        /     %p Would you like to subscribe to the IFF Mailing List? You don’t want to miss important updates!
+        /     = f.collection_radio_buttons :include_in_mailings, [[true, "Yes, keep me updated!"], [false, "No, thank you"]], :first, :last, checked: true
+        / .row
+        /   .span16
+        /     <br /><br />
+        /     = f.input :already_mailing, as: :boolean, boolean_style: :inline, label: "I'm already subscribed to the IFF Mailing List."
+        / .row
+        /   .span16
+        /     <hr />    
+        /     %p Invitation to Mattermost: Mattermost provides a real-time chat service where you can talk to other participants of IFF.
+        /     = f.collection_radio_buttons :invitation_to_mattermost, [[true, "Yes, please"], [false, "No, thank you"]], :first, :last, checked: true
+        / .row
+        /   .span16
+        /     <br /><br />
+        /     = f.input :already_mattermost, as: :boolean, boolean_style: :inline, label: "I'm already a member of the IFF Mattermost?"
+        .row
+          .span16
             <hr />
             %p Would you like to subscribe to the IFF Mailing List? You don’t want to miss important updates!
-            = f.collection_radio_buttons :include_in_mailings, [[true, "Yes, keep me updated!"], [false, "No, thank you"]], :first, :last, checked: true
+            = f.input :complete_mailing, label: "Invitation to Mailing?", collection: ["Yes", "No", "Already Subscribed"], error: " "
         .row
           .span16
-            <br /><br />
-            = f.input :already_mailing, as: :boolean, boolean_style: :inline, label: "I'm already subscribed to the IFF Mailing List."
-        .row
-          .span16
-            <hr />    
-            %p Invitation to Mattermost: Mattermost provides a real-time chat service where you can talk to other participants of IFF.
-            = f.collection_radio_buttons :invitation_to_mattermost, [[true, "Yes, please"], [false, "No, thank you"]], :first, :last, checked: true
-        .row
-          .span16
-            <br /><br />
-            = f.input :already_mattermost, as: :boolean, boolean_style: :inline, label: "I'm already a member of the IFF Mattermost?"
+            <hr />
+            %p Mattermost provides a real-time chat service where you can talk to other participants of IFF.
+            = f.input :complete_mattermost, label: "Invitation to Mattermost?", collection: ["Yes", "No", "Already Subscribed"], error: " "
         .row
           .span16
             <hr />

--- a/db/migrate/20171018192405_add_mattermost_and_mailing_complete_to_person.rb
+++ b/db/migrate/20171018192405_add_mattermost_and_mailing_complete_to_person.rb
@@ -1,0 +1,6 @@
+class AddMattermostAndMailingCompleteToPerson < ActiveRecord::Migration
+  def change
+    add_column :people, :complete_mailing, :string
+    add_column :people, :complete_mattermost, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171012210649) do
+ActiveRecord::Schema.define(version: 20171018192405) do
 
   create_table "availabilities", force: :cascade do |t|
     t.integer  "person_id"
@@ -328,6 +328,8 @@ ActiveRecord::Schema.define(version: 20171012210649) do
     t.boolean  "already_mattermost"
     t.string   "twitter"
     t.string   "personal_website"
+    t.string   "complete_mailing"
+    t.string   "complete_mattermost"
   end
 
   add_index "people", ["email"], name: "index_people_on_email"


### PR DESCRIPTION
…ration. Add form fields to cfp person registration. Add new columns to Person strong params in Person controller. Comment out validation of gender, public_name uniq, and country of origin, prof back, and iff before on update to allow update of all people in production (checking already_mattermost, already_mailing, include_mailing, invitation_to_mattermost and updating their complete_mattermost and complete_mailing accordingly). Comment out forms for invitation to mattermost/mailings and replace with completes.