### PR TITLE
Add column to users (MIGRATION) as confirm_attendance_token.  Add con…

### DIFF
--- a/app/controllers/cfp/confirmations_controller.rb
+++ b/app/controllers/cfp/confirmations_controller.rb
@@ -27,4 +27,18 @@ class Cfp::ConfirmationsController < ApplicationController
       redirect_to new_cfp_user_confirmation_path, error: t('cfp.error_confirming')
     end
   end
+
+  def confirm_attendance
+    confirmation_token = params[:confirm_attendance_token]
+    user = User.find_by(confirm_attendance_token: confirmation_token)
+    if user
+      person = user.person
+      if person.update(attendance_status: "confirmed")
+        flash[:sucess] = "Your attendance status has been confirmed!"
+      else
+        flash[:danger] = "There was an error updating your attendance status. Please contact us."
+      end
+    end
+    redirect_to root_path
+  end
 end

--- a/app/controllers/mail_templates_controller.rb
+++ b/app/controllers/mail_templates_controller.rb
@@ -15,7 +15,10 @@ class MailTemplatesController < ApplicationController
     @mail_template = @conference.mail_templates.find(params[:id])
     @send_filter_options = [
       ['All speakers involved in all confirmed events',   :all_speakers_in_confirmed_events],
-      ['All speakers involved in all unconfirmed events', :all_speakers_in_unconfirmed_events]
+      ['All speakers involved in all unconfirmed events', :all_speakers_in_unconfirmed_events],
+      ['All people with pending attendance', :all_pending_attendance_people],
+      ['All people with confirmed attendance', :all_confirmed_attendance_people],
+      ['Test: Send to Pepe and Jamie only', :pepe_and_jamie]
     ]
   end
 

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -278,6 +278,23 @@ class PeopleController < ApplicationController
     end
   end
 
+  def generate_confirmation_tokens
+    users_to_generate_token = []
+    users = User.where(confirm_attendance_token: nil)
+    
+    users.each do |user|
+      if user.person && user.person.attendance_status == 'pending acceptance'
+        users_to_generate_token << user
+      end
+    end
+
+    users_to_generate_token.each do |user|
+      user.generate_confirm_attendance_token!
+    end
+    redirect_to root_path
+  end
+
+
   private
 
   def restrict_people

--- a/app/jobs/send_bulk_mail_job.rb
+++ b/app/jobs/send_bulk_mail_job.rb
@@ -16,8 +16,16 @@ class SendBulkMailJob
       persons = persons
                 .where('events.state': 'unconfirmed')
                 .where('event_people.event_role': 'speaker')
+    when 'all_pending_attendance_people'
+      persons = Person
+                .where('attendance_status': 'pending attendance')
+    when 'all_confirmed_attendance_people'
+      persons = Person
+                .where('attendance_status': 'confirmed')
+    when 'pepe_and_jamie'
+      persons = Person
+                .where(email: ['jamie.mackillop.jobs@gmail.com', 'pborras@internetfreedomfestival.org'])
     end
-
     persons = persons.group(:'people.id')
 
     persons.each do |p|

--- a/app/models/mail_template.rb
+++ b/app/models/mail_template.rb
@@ -9,6 +9,7 @@ class MailTemplate < ActiveRecord::Base
       .gsub('#first_name',  user.first_name)
       .gsub('#last_name',   user.last_name)
       .gsub('#public_name', user.public_name)
+      .gsub('#confirm_attendance', "https://platform.internetfreedomfestival.org/en/iff-2018/cfp/user/confirmation/confirm_attendance?confirm_attendance_token=#{user.user.confirm_attendance_token}")
   end
 
   def send_sync(filter)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -115,6 +115,11 @@ class User < ActiveRecord::Base
     conference_users.map(&:conference).last
   end
 
+  def generate_confirm_attendance_token!
+    generate_token_for(:confirm_attendance_token)
+    save
+  end
+
   private
 
   def conference_user_fields_present

--- a/app/views/mail_templates/_form.html.haml
+++ b/app/views/mail_templates/_form.html.haml
@@ -6,6 +6,7 @@
     %li #first_name
     %li #last_name
     %li #public_name
+    %li #confirm_attendance
 
 = simple_form_for @mail_template do |f|
   %fieldset.inputs

--- a/app/views/people/all.html.haml
+++ b/app/views/people/all.html.haml
@@ -2,6 +2,7 @@
   .page-header
     .pull-right
       - if can? :administrate, Person
+        = action_button "success", "Generate Confirmation Tokens", generate_confirmation_tokens_people_path, title: "This will generate tokens for users with pending attendance. This will allow them to confirm their attendance via email at a later time."
         = action_button "primary", "Add person", new_person_path, title: "Add a new person."
     %h1 List of people
   %ul.tabs

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,7 +37,11 @@ Frab::Application.routes.draw do
 
         resource :user do
           resource :password
-          resource :confirmation
+          resource :confirmation do
+            member do
+              get '/confirm_attendance' => :confirm_attendance
+            end
+          end
         end
 
         resource :person do
@@ -110,6 +114,7 @@ Frab::Application.routes.draw do
           get :waitlisted
           get :invite
           get :canceled
+          get :generate_confirmation_tokens
         end
       end
 

--- a/db/migrate/20180111210948_add_attendance_token_to_user.rb
+++ b/db/migrate/20180111210948_add_attendance_token_to_user.rb
@@ -1,0 +1,5 @@
+class AddAttendanceTokenToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :confirm_attendance_token, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171222162423) do
+ActiveRecord::Schema.define(version: 20180111210948) do
 
   create_table "availabilities", force: :cascade do |t|
     t.integer  "person_id"
@@ -416,24 +416,25 @@ ActiveRecord::Schema.define(version: 20171222162423) do
   add_index "transport_needs", ["person_id"], name: "index_transport_needs_on_person_id"
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                limit: 255, default: "",          null: false
-    t.string   "password_digest",      limit: 255, default: "",          null: false
-    t.string   "reset_password_token", limit: 255
+    t.string   "email",                    limit: 255, default: "",          null: false
+    t.string   "password_digest",          limit: 255, default: "",          null: false
+    t.string   "reset_password_token",     limit: 255
     t.datetime "remember_created_at"
-    t.string   "remember_token",       limit: 255
-    t.integer  "sign_in_count",                    default: 0
+    t.string   "remember_token",           limit: 255
+    t.integer  "sign_in_count",                        default: 0
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.string   "current_sign_in_ip",   limit: 255
-    t.string   "last_sign_in_ip",      limit: 255
-    t.string   "confirmation_token",   limit: 255
+    t.string   "current_sign_in_ip",       limit: 255
+    t.string   "last_sign_in_ip",          limit: 255
+    t.string   "confirmation_token",       limit: 255
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
-    t.datetime "created_at",                                             null: false
-    t.datetime "updated_at",                                             null: false
-    t.string   "role",                 limit: 255, default: "submitter"
-    t.string   "pentabarf_salt",       limit: 255
-    t.string   "pentabarf_password",   limit: 255
+    t.datetime "created_at",                                                 null: false
+    t.datetime "updated_at",                                                 null: false
+    t.string   "role",                     limit: 255, default: "submitter"
+    t.string   "pentabarf_salt",           limit: 255
+    t.string   "pentabarf_password",       limit: 255
+    t.string   "confirm_attendance_token"
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true


### PR DESCRIPTION
…firm_attendance method in cfp confirmations controller that receives params from confirmation email link, finds the user, and updates their person attendance status to confirmed. Add drop down options for mail template recipients. Add token generator method/button for admin to update all users whose person has a pending acceptance by giving them a confirm_attendance_token. Add variable to mail template to allow for links to confirm their attendance.